### PR TITLE
Fix segfault when loading multiple Charm gems together

### DIFF
--- a/ext/lipgloss/extconf.rb
+++ b/ext/lipgloss/extconf.rb
@@ -42,16 +42,20 @@ unless File.exist?(File.join(go_lib_dir, "liblipgloss.a"))
   ERROR
 end
 
+go_lib_path = File.join(go_lib_dir, "liblipgloss.a")
+
 $LDFLAGS << " -L#{go_lib_dir}"
 $INCFLAGS << " -I#{go_lib_dir}"
 
-$LOCAL_LIBS << " #{go_lib_dir}/liblipgloss.a"
-
 case RbConfig::CONFIG["host_os"]
 when /darwin/
+  $LDFLAGS << " -Wl,-load_hidden,#{go_lib_path}"
+  $LDFLAGS << " -Wl,-exported_symbol,_Init_lipgloss"
   $LDFLAGS << " -framework CoreFoundation -framework Security -framework SystemConfiguration"
   $LDFLAGS << " -lresolv"
 when /linux/
+  $LOCAL_LIBS << " #{go_lib_path}"
+  $LDFLAGS << " -Wl,--exclude-libs,ALL"
   $LDFLAGS << " -lpthread -lm -ldl"
   $LDFLAGS << " -lresolv" if find_library("resolv", "res_query")
 end


### PR DESCRIPTION
## Summary

When lipgloss and bubbletea are loaded together in the same Ruby process, calling Go-backed functions causes a segfault due to Go runtime symbol clashes. Each gem embeds a full Go runtime via `c-archive`, and the duplicate symbols collide when both runtimes are active.

This is especially problematic with cross-compiled gems (via rake-compiler-dock), where Ruby's rbconfig adds `-Wl,-flat_namespace` - putting all symbols into a single global pool.

## Fix

- **macOS**: Use `-load_hidden` to link the Go static archive with all symbols hidden, and `-exported_symbols_list` to export only `_Init_lipgloss`.
- **Linux**: Use a linker `--version-script` to achieve the same: export only `Init_lipgloss`, hide everything else.

This reduces exported symbols from ~60 to 1, eliminating all clashes between gems.